### PR TITLE
Remove stray d. that causes an error

### DIFF
--- a/notebooks/Jupyter_widget.ipynb
+++ b/notebooks/Jupyter_widget.ipynb
@@ -247,7 +247,6 @@
     "d = rdMolDraw2D.MolDraw2DSVG(200,150)\n",
     "dm = Draw.PrepareMolForDrawing(m)\n",
     "d.DrawMolecule(dm)\n",
-    "d.\n",
     "d.FinishDrawing()\n",
     "svg = d.GetDrawingText()\n",
     "w = MolSVGWidget(svg=svg)\n",


### PR DESCRIPTION
Seems like the intention was to have `d.TagAtoms(dm)`, and that didn't work, then the lone `d.` got left in by accident, causing `SyntaxError: invalid syntax`.