### PR TITLE
Mols matrix to grid image fixes

### DIFF
--- a/notebooks/Plotting Rows and Columns of Molecules with MolsMatrixToGridImage.ipynb
+++ b/notebooks/Plotting Rows and Columns of Molecules with MolsMatrixToGridImage.ipynb
@@ -681,12 +681,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| `MolsToGridImage`<br>_`MolsMatrixToGridImage`_ | Elements mean                   | Parameter name                                   | Data structure                                                     | Example                                                                                                                                                                                      |\n",
+    "| Key to table lines within a cell:<br>`MolsToGridImage`_<br>`MolsMatrixToGridImage`<br>_ |\n",
+    "|---------------------------------------------------------------------------------------------|"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "|  | Elements mean                   | Parameter name                                   | Data structure                                                     | Example                                                                                                                                                                                      |\n",
     "|----------------------------------------------------|-------------------------------|--------------------------------------------------|---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|\n",
-    "| Molecules                                          | RDKit molecule                | mols<br>_molsMatrix_                             | Iterable[mol]<br>_Iterable[Iterable[mol]]_                    | [FCl, FCl, None, FCl, None, FCl]<br>_[[FCl, FCl], [FCl, None, FCl]]_                                                                                                                         |\n",
-    "| Legends                                            | Legend text                   | legends<br>_legendsMatrix_                       | Iterable[str]<br>_Iterable[Iterable[str]]_                    | [\"no highlighting\", \"bond highlighted\", \"\", \"F highlighted\", \"\", \"Cl and bond highlighted\"]<br>_[[\"no highlighting\", \"bond highlighted\"], [\"F highlighted\", \"\", \"Cl and bond highlighted\"]]_ |\n",
-    "| Highlight atoms                                    | Indices of atoms to highlight | highlightAtomLists<br>_highlightAtomListsMatrix_ | Iterable[Iterable[int]]<br>_Iterable[Iterable[Iterable[Int]]_ | [[], [], None, [0], None, [1]]<br>_[[[], []], [[0], None, [1]]]_                                                                                                                               |\n",
-    "| Highlight bonds                                    | Indices of bonds to highlight | highlightBondLists<br>_highlightBondListsMatrix_ | Iterable[Iterable[int]]<br>_Iterable[Iterable[Iterable[Int]]_ | [[], [0], None, [], None, [0]]<br>_[[[], [0]], [[], None, [0]]]_                                                                                                                               |"
+    "| Molecules                                          | RDKit molecule                | mols<br>_molsMatrix_                             | Iterable[mol]<br>_Iterable[<wbr>Iterable[mol]]_                    | [FCl, FCl, None, FCl, None, FCl]<br>_[[FCl, FCl], [FCl, None, FCl]]_                                                                                                                         |\n",
+    "| Legends                                            | Legend text                   | legends<br>_legendsMatrix_                       | Iterable[str]<br>_Iterable[<wbr>Iterable[<wbr>str]]_                    | [\"no highlighting\", \"bond highlighted\", \"\", \"F highlighted\", \"\", \"Cl and bond highlighted\"]<br>_[[\"no highlighting\", \"bond highlighted\"], [\"F highlighted\", \"\", \"Cl and bond highlighted\"]]_ |\n",
+    "| Highlight atoms                                    | Indices of atoms to highlight | highlightAtomLists<br>_highlightAtomListsMatrix_ | Iterable[Iterable[int]]<br>_Iterable[<wbr>Iterable[<wbr>Iterable[<wbr>Int]]_ | [[], [], None, [0], None, [1]]<br>_[[[], []], [[0], None, [1]]]_                                                                                                                               |\n",
+    "| Highlight bonds                                    | Indices of bonds to highlight | highlightBondLists<br>_highlightBondListsMatrix_ | Iterable[Iterable[int]]<br>_Iterable[<wbr>Iterable[<wbr>Iterable[<wbr>Int]]_ | [[], [0], None, [], None, [0]]<br>_[[[], [0]], [[], None, [0]]]_                                                                                                                               |"
    ]
   },
   {

--- a/notebooks/Plotting Rows and Columns of Molecules with MolsMatrixToGridImage.ipynb
+++ b/notebooks/Plotting Rows and Columns of Molecules with MolsMatrixToGridImage.ipynb
@@ -129,13 +129,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### When to use MolsToGridImage vs. MolsMatrixToGridImage\n",
+    "### Choosing a grid image function\n",
     "\n",
     "Use `MolsToGridImage` if you want to plot a series of molecules in the least amount of space, where the row that each molecule is on is not important.\n",
     "\n",
     "Use `MolsMatrixToGridImage` if you want each row of molecules to represent something meaningful, and especially if the number of molecules per row can vary. The *columns* may or may not have meaning: You could plot an uninterrupted series of molecules in a row in no particular order, or you could assign molecules to columns based on some property—for example, a column may represent a spatial location. Or the columns may be used to space out molecules; for example in the retrosynthetic analysis tree below, the columns allow horizontal space for each subtree to avoid visually-confusing overlapping with adjacent subtrees.\n",
     "\n",
     "A borderline situation is if each row will have the same number of molecules `n` (`n` = 2 below): you can create the same grid using either\n",
+    "\n",
     "- `MolsToGridImage(molsPerRow=n)`, for example `MolsToGridImage([mol1a, mol1b, mol2a, mol2b, mol3a, mol3b], molsPerRow=2)`.\n",
     "- `MolsMatrixToGridImage` with `n` molecules in each row, for example `MolsMatrixToGridImage([[mol1a, mol1b], [mol2a, mol2b], [mol3a, mol3b]])`. You may find this format easier to use because each row is in its own sub-list. Also, you need not explicitly declare the number of molecules per row, so if you later change that number `n`, or have a different number of molecules on a given row, the grid will automatically adjust accordingly."
    ]
@@ -144,7 +145,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note: Both `MolsMatrixToGridImage` and `MolsToGridImage` are Python functions; they are not available in C++."
+    "Both `MolsMatrixToGridImage` and `MolsToGridImage` are Python functions; they are not available in C++."
    ]
   },
   {
@@ -170,6 +171,7 @@
     "Given molecules you want to synthesize, and the reaction to create each, this utility determines the starting materials, checks whether they are commercially available per PubChem, and tells you whether each target is accessible—whether all its starting materials are commercially available.\n",
     "\n",
     "Here, `MolsMatrixToGridImage` is useful because\n",
+    "\n",
     "- each row represents a synthetic target\n",
     "- each target might have a different number of starting materials, and thus a different number of cells (columns). The first column represents the target. Subsequent columns represent the reactants, and are in no particular order."
    ]
@@ -228,11 +230,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### [Find the maximum common substructure, and groups off it, for a set of molecules](https://bertiewooster.github.io/2022/12/25/RDKit-Find-Groups-Off-Common-Core.html)\n",
+    "### [Find the maximum common substructure and groups off it](https://bertiewooster.github.io/2022/12/25/RDKit-Find-Groups-Off-Common-Core.html)\n",
     "\n",
     "In drug discovery, the lead optimization step often involves creating analogues of a hit (a promising compound which produces a desired result in an assay) to optimize selectivity and minimize toxicity. Because it has historically been easier to chemically modify the periphery of the molecule (for example the functional groups) than the scaffold, it is helpful to compare the groups off of the common scaffold. A utility function uses the RDKit to find the maximum common substructure (MCS) between a set of molecules, then show the groups off of that core scaffold.\n",
     "\n",
     "Here, `MolsMatrixToGridImage` is useful because\n",
+    "\n",
     "- each row represents a molecule in the set\n",
     "- each of those molecules might have a different number of groups off the core scaffold.\n",
     "The first column represents the molecule. Subsequent columns represent the groups off the core scaffold for that molecule, and are in no particular order.\n",
@@ -602,6 +605,7 @@
     "Retrosynthetic analysis involves decomposing a target molecule into a set of fragments that could be combined to make the parent molecule using common reactions. The [Recap algorithm](https://www.semanticscholar.org/paper/RECAP-%E2%80%94-Retrosynthetic-Combinatorial-Analysis-A-New-Lewell-Judd/fbfb10d1f63aa803f6d47df6587aa0e41109f5ee) by X. Lewell et al. accomplishes that. [Recap is implemented in the RDKit](https://www.rdkit.org/docs/GettingStartedInPython.html#recap-implementation). \n",
     "\n",
     "Here, `MolsMatrixToGridImage` is useful because\n",
+    "\n",
     "- each row represents a level of fragmentation, with the parent molecule at the top and increasing fragmentation towards the bottom\n",
     "- we want to arrange the fragments hierarchically and allow horizontal space for each subtree to avoid visually-confusing overlapping with adjacent subtrees.\n",
     "The columns have no inherent meaning, except that the parent molecule is in the first column, and fragments (of the parent molecule and its fragments) are arrayed to the right.\n",
@@ -696,7 +700,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you provide the parameter names in the function call, for example `MolsMatrixToGridImage(molsMatrix=molsMatrix, legendsMatrix=legendsMatrix)`, be careful to include the suffix \"Matrix\" in those last three parameter names; if you use the parameter name from `MolsToGridImage`, such as `legends`, it will be passed to `MolsToGridImage` as a keyword argument and you will get an error like:\n",
+    "If you provide the parameter names in the function call, for example `MolsMatrixToGridImage(molsMatrix=molsMatrix, legendsMatrix=legendsMatrix)`, be careful to include the suffix \"Matrix\" in those last three parameter names: if you use the parameter name from `MolsToGridImage`, such as `legends`, it will be passed to `MolsToGridImage` as a keyword argument and you will get an error like:\n",
     "\n",
     "`TypeError: rdkit.Chem.Draw.IPythonConsole.ShowMols() got multiple values for keyword argument 'legends'`"
    ]
@@ -705,14 +709,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that, unlike `MolsToGridImage`, `MolsMatrixToGridImage` does not take a `molsPerRow` parameter because `MolsMatrixToGridImage` automatically sets the number of molecules per row to the length of the longest row in `molsMatrix`. Other than that, and the per-molecule parameters having a more nested structure, `MolsMatrixToGridImage` can accept all the same parameters as `MolsToGridImage`: `useSVG`, `returnPNG`, and `**kwargs` such as `drawOptions`. Indeed, `MolsMatrixToGridImage` passes those three parameters to `MolsToGridImage`."
+    "Unlike `MolsToGridImage`, `MolsMatrixToGridImage` does not take a `molsPerRow` parameter because `MolsMatrixToGridImage` automatically sets the number of molecules per row to the length of the longest row in `molsMatrix`. Other than that, and the per-molecule parameters having a more nested structure, `MolsMatrixToGridImage` can accept all the same parameters as `MolsToGridImage`: `useSVG`, `returnPNG`, and `**kwargs` such as `drawOptions`. Indeed, `MolsMatrixToGridImage` passes those three parameters to `MolsToGridImage`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Requirements for agreement of dimensions of per-molecule parameters in `MolsMatrixToGridImage`\n",
+    "### Requirements for agreement of dimensions of per-molecule parameters\n",
     "\n",
     "`molsMatrix` sets the dimensions, and any other supplied Matrix (per-molecule) parameters must match those dimensions. In the example in the table above, `molsMatrix` has two rows (sub-lists), so `legendsMatrix`, `highlightAtomListsMatrix`, and `highlightBondListsMatrix` (if supplied) must also have two rows. Also, because the first row (sub-list) of `molsMatrix` has two columns (elements), that must true for those three other parameters. And because the second row (sub-list) of `molsMatrix` has three columns (elements), that must true for those three other parameters."
    ]
@@ -721,7 +725,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Making blank cells\n",
+    "### Inserting blank cells\n",
     "\n",
     "For blank cells at the end of a row, `MolsMatrixToGridImage` will automatically create them so that all rows have the same number of cells.\n",
     "\n",
@@ -810,7 +814,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example with all parameters for MolsMatrixToGridImage\n",
+    "### Example with all parameters\n",
     "\n",
     "Here is an example of supplying all parameters to `MolsMatrixToGridImage`."
    ]


### PR DESCRIPTION
First commit is to fix bullets rendering as `-` instead.

Second commit attempts to make table less wide (it collides with right navbar) and allow more width for the last column (it's very narrow) by moving key to a separate table, and putting <wbr> (word break opportunity) in long lines. If you don't want to make those compromises, feel free to merge only the first commit.