### PR TITLE
Fix Murcko blog formatting issue

### DIFF
--- a/notebooks/Murcko Scaffolds.ipynb
+++ b/notebooks/Murcko Scaffolds.ipynb
@@ -307,6 +307,7 @@
    "metadata": {},
    "source": [
     "For the last setup step, we create the legends by row (scaffold):\n",
+    "\n",
     "- In the first column, we number each scaffold\n",
     "- In the second column, we tell how many molecules correspond to that scaffold"
    ]


### PR DESCRIPTION
In one spot, bullets aren't rendered correctly: they show up on the same line (paragraph). This simply adds a blank line before the first bullet to fix that.