### PR TITLE
Update URL of blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ rdkit_blog
 
 RDKit related blog posts, notebooks, and data.
 
-The blog itself is located here: http://rdkit.blogspot.com
+The blog itself is located here: https://greglandrum.github.io/rdkit-blog


### PR DESCRIPTION
Also suggest updating the PyPI installation instructions in the [about page](https://greglandrum.github.io/rdkit-blog/about.html) to:

> You can also install the RDKit from PyPI: pip install rdkit

(The source file for the about page doesn't seem to be in the repo so I can't include this suggestion in the pull request itself.)